### PR TITLE
[RFR] Add end of file new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ Asynchronously writes data to a file, replacing the file if it already exists an
 
 * `filepath` **{string|Buffer|integer}**: filepath or file descriptor.
 * `data` **{string|Buffer|Uint8Array}**: String to write to disk.
-* `options` **{object}**: Options to pass to [fs.writeFile](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback) and/or [mkdirp](https://github.com/substack/node-mkdirp)
+* `options` **{object}**: Options to pass to [fs.writeFile](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback) and/or [mkdirp](https://github.com/substack/node-mkdirp). Some extra options can also be passed (see below)
 * `callback` **{Function}**: (optional) If no callback is provided, a promise is returned.
+
+**Custom options:**
+
+In addition to [fs.writeFile](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback) and [mkdirp](https://github.com/substack/node-mkdirp) options, you can also pass some `write` specific options:
+
+* `ensureNewLine`: force a new line (`\n`) at the end of the file
 
 **Example**
 
@@ -138,7 +144,7 @@ Pull requests and stars are always welcome. For bugs and feature requests, [plea
 
 ### Contributors
 
-| **Commits** | **Contributor** | 
+| **Commits** | **Contributor** |
 | --- | --- |
 | 33 | [jonschlinkert](https://github.com/jonschlinkert) |
 | 1 | [tunnckoCore](https://github.com/tunnckoCore) |

--- a/index.js
+++ b/index.js
@@ -57,7 +57,9 @@ function writeFile(filepath, data, options, cb) {
       cb(err);
       return;
     }
-    fs.writeFile(filepath, data, options, cb);
+
+    var withEndNewLine = data.slice(-1) === "\n" ? data : data + "\n";
+    fs.writeFile(filepath, withEndNewLine, options, cb);
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -58,8 +58,12 @@ function writeFile(filepath, data, options, cb) {
       return;
     }
 
-    var withEndNewLine = data.slice(-1) === "\n" ? data : data + "\n";
-    fs.writeFile(filepath, withEndNewLine, options, cb);
+    var preparedData = data;
+    if (options && options.ensureNewLine && data.slice(-1) !== "\n") {
+      preparedData += "\n";
+    }
+
+    fs.writeFile(filepath, preparedData, options, cb);
   });
 };
 

--- a/test.js
+++ b/test.js
@@ -33,35 +33,52 @@ describe('write', function() {
     });
   });
 
-  describe('End New Line', () => {
-    it('should add a new line at the end of the file if none', (done) => {
+  describe('End New Line', function () {
+    it('should just write given data by default', function (done) {
       each(files, function (fp, next) {
-        writeFile(fp, 'Hello!', () => {
+        writeFile(fp, 'Hello!', function () {
           fs.readFile(fp, function (err, fileContent) {
             if (err) {
               return next(err);
             }
 
-            assert.equal('Hello!\n', fileContent.toString());
+            assert.equal('Hello!', fileContent.toString());
             next();
           });
         });
       }, done);
     });
 
-    it('should not add a new line at the end of the file if there is already one', (done) => {
-      each(files, function (fp, next) {
-        writeFile(fp, "Hello!\n", () => {
-          fs.readFile(fp, function (err, fileContent) {
-            if (err) {
-              return next(err);
-            }
+    describe('With `ensureNewLine` option to true', function () {
+      it('should add a new line at the end of the file if none', function (done) {
+        each(files, function (fp, next) {
+          writeFile(fp, 'Hello!', { ensureNewLine: true }, function () {
+            fs.readFile(fp, function (err, fileContent) {
+              if (err) {
+                return next(err);
+              }
 
-            assert.equal('Hello!\n', fileContent.toString());
-            next();
+              assert.equal('Hello!\n', fileContent.toString());
+              next();
+            });
           });
-        });
-      }, done);
+        }, done);
+      });
+
+      it('should not add a new line at the end of the file if there is already one', function (done) {
+        each(files, function (fp, next) {
+          writeFile(fp, "Hello!\n", { ensureNewLine: true }, function() {
+            fs.readFile(fp, function (err, fileContent) {
+              if (err) {
+                return next(err);
+              }
+
+              assert.equal('Hello!\n', fileContent.toString());
+              next();
+            });
+          });
+        }, done);
+      });
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -33,6 +33,38 @@ describe('write', function() {
     });
   });
 
+  describe('End New Line', () => {
+    it('should add a new line at the end of the file if none', (done) => {
+      each(files, function (fp, next) {
+        writeFile(fp, 'Hello!', () => {
+          fs.readFile(fp, function (err, fileContent) {
+            if (err) {
+              return next(err);
+            }
+
+            assert.equal('Hello!\n', fileContent.toString());
+            next();
+          });
+        });
+      }, done);
+    });
+
+    it('should not add a new line at the end of the file if there is already one', (done) => {
+      each(files, function (fp, next) {
+        writeFile(fp, "Hello!\n", () => {
+          fs.readFile(fp, function (err, fileContent) {
+            if (err) {
+              return next(err);
+            }
+
+            assert.equal('Hello!\n', fileContent.toString());
+            next();
+          });
+        });
+      }, done);
+    });
+  });
+
   describe('async', function() {
     it('should write files', function(cb) {
       each(files, function(fp, next) {


### PR DESCRIPTION
As explained [here](https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file), each file should have a new line at the end. It especially helps when `cat`-ting files directly in terminal. 

This PR adds it if it doesn't already exist.

